### PR TITLE
修复关闭overlap模式后点击按钮 模式切换前的音频继续播放的问题

### DIFF
--- a/src/view/Player.vue
+++ b/src/view/Player.vue
@@ -80,9 +80,7 @@ export default {
         })
       }
       if (!this.playSetting.overlap) {
-        if (this.playerList.has('once')) {
-          this.playerList.get('once').audio.pause()
-        }
+        this.stopPlay()
         this.addPlayer(voice, 'once')
       } else {
         const key = new Date().getTime()


### PR DESCRIPTION
在从可重复播放模式时切换到单次播放模式后
当之前的音频未播放完而点击新的音频时,之前的音频不会停止播放